### PR TITLE
Update client.py

### DIFF
--- a/statsd/client.py
+++ b/statsd/client.py
@@ -79,8 +79,8 @@ class StatsClientBase(object):
     def pipeline(self):
         pass
 
-    def timer(self, stat, rate=1):
-        return Timer(self, stat, rate)
+    def timer(self, stat, rate=1, tags=None):
+        return Timer(self, stat, rate, tags=None)
 
     def timing(self, stat, delta, rate=1, tags=None):
         """Send new timing information. `delta` is in milliseconds."""


### PR DESCRIPTION
fixing that you cant use
```
with statsd.timer('some.event', tags={'hello': 'world'}):
    time.sleep(1)
```